### PR TITLE
Prevent Radau step size from going to nan when system doesn't change

### DIFF
--- a/scipy_ode/radau.py
+++ b/scipy_ode/radau.py
@@ -453,7 +453,8 @@ def predict_factor(h_abs, h_abs_old, error_norm, error_norm_old):
            Equations II: Stiff and Differential-Algebraic Problems", Sec. IV.8.
     """
     with np.errstate(divide='ignore'):
-        if error_norm_old is None or h_abs_old is None:
+        if error_norm_old is None or h_abs_old is None \
+                or error_norm_old == 0 or error_norm == 0:
             multiplier = 1
         else:
             multiplier = h_abs / h_abs_old * (error_norm_old /

--- a/scipy_ode/tests/test_ivp.py
+++ b/scipy_ode/tests/test_ivp.py
@@ -2,7 +2,7 @@ from __future__ import division, print_function, absolute_import
 
 import numpy as np
 from numpy.testing import (assert_, assert_allclose, run_module_suite,
-                           assert_equal, assert_raises)
+                           assert_equal, assert_raises, assert_no_warnings)
 from scipy_ode import SolverStatus, solve_ivp, RungeKutta23, RungeKutta45, Radau
 
 
@@ -220,6 +220,17 @@ def test_equilibrium():
 
         static_result = sol(100)
         assert_allclose(static_result, known_reference, rtol=1e-2)
+
+
+def test_flat():
+    def fun(t, y):
+        return np.zeros(y.shape)
+
+    ic = [0, 0]
+
+    for method in all_methods:
+        sol = assert_no_warnings(solve_ivp, fun, ic, 0, 10, method=method)
+        assert_allclose(sol(10), [0, 0], rtol=1e-2)
 
 
 def test_parameters_validation():


### PR DESCRIPTION
If the RHS is all zeros, Radau throws 0/0 warnings when trying to compute the multiplier for the next step size. I applied a fix that squelches the warning and passes the tests. But I am not that familiar with the math, so I wanted @nmayorov to take a look at it before I committed this change. There may be a better solution that I can't see.